### PR TITLE
Fix missing ec2-tunnel user

### DIFF
--- a/infra/bastion_user_data.tpl
+++ b/infra/bastion_user_data.tpl
@@ -17,6 +17,8 @@ users:
 %{ for key in ec2_user_public_keys ~}
       - ${key}
 %{ endfor ~}
+  - name: ec2-tunnel
+    sudo: False
 
 --//
 Content-Type: text/x-shellscript; charset="us-ascii"


### PR DESCRIPTION
The ec2-tunnel user got accidentally removed in 942ed89656fcee6e073d6e23d166ebc8fbe9d063