### PR TITLE
Fix logging path

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,7 +78,7 @@ services:
       - db
       - mock_xroad
     volumes:
-      - ./logs:/var/task/logs
+      - ./logs:/tmp/logs
       - ./lambdas/ryhti_client/ryhti_client:/var/task/ryhti_client
       - ./lambdas/ryhti_client/lambda_function.py:/var/task/lambda_function.py
       - ./database:/var/task/database

--- a/lambdas/ryhti_client/ryhti_client/ryhti_client.py
+++ b/lambdas/ryhti_client/ryhti_client/ryhti_client.py
@@ -37,7 +37,10 @@ class RyhtiResponse(TypedDict):
 
 
 def save_debug_json(filename: str, data: Any) -> None:
-    with Path("logs", filename).open("w", encoding="utf-8") as f:
+    logging_folder = Path("/tmp/logs")  # noqa: S108
+    logging_folder.mkdir(exist_ok=True)
+
+    with Path(logging_folder, filename).open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=4, ensure_ascii=False)
 
 


### PR DESCRIPTION
On aws environment only the /tmp folder is writable. If debug logs are requested in the payload this previously crashed.